### PR TITLE
Set the output environment variable on failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -189,6 +189,10 @@ def execute_command(command):
                 err.returncode, err.with_traceback, err.output
             )
         )
+
+        if err.returncode == 2:
+            return err.output
+
         raise
     except Exception as err:
         print(f"Unexpected {err=}, {type(err)=}")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Assign the result to the GITHUB_OUTPUT env vars when the error is from the CLI tool due to blocking findings

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
