### PR TITLE
Update the version of tf-policy-validator to 0.0.9.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.10
 # Install tf-policy-validator
 # Cloning the `terraform-iam-policy-validator` repo for default config for terraform templates
 # ToDo: Once we start using the tags for releases, we should use the tag associated with the version we download by using flag --branch <tag>
-RUN pip install tf-policy-validator==0.0.8 && git clone https://github.com/awslabs/terraform-iam-policy-validator.git
+RUN pip install tf-policy-validator==0.0.9 && git clone https://github.com/awslabs/terraform-iam-policy-validator.git
 
 ENV TERRAFORM_CONFIG_DEFAULT=/terraform-iam-policy-validator/iam_check/config/default.yaml
 


### PR DESCRIPTION
*Description of changes:*
Updating the version of tf-policy-validator. The new version will support the following resource types in check-no-public-access api.

AWS::S3Tables::TableBucket
AWS::S3Tables::Table
AWS::Backup::BackupVault
AWS::CodeArtifact::Domain
AWS::ApiGateway::RestApi
AWS::Lambda::Function
AWS::DynamoDB::Table
AWS::Kinesis::Stream
AWS::Kinesis::StreamConsumer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
